### PR TITLE
Fix code scanning alert no. 26: Expression injection in Actions

### DIFF
--- a/.github/workflows/ci-build-push-dockerhub.yaml
+++ b/.github/workflows/ci-build-push-dockerhub.yaml
@@ -34,8 +34,10 @@ jobs:
           fetch-depth: 0
           
       - name: INFO | Debugging info
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          echo '${{ github.event.head_commit.message }}'
+          echo "$COMMIT_MESSAGE"
           echo '${{ github.base_ref }}'
           echo '${{ github.ref }}'
       


### PR DESCRIPTION
Fixes [https://github.com/osherlevi7/dev/security/code-scanning/26](https://github.com/osherlevi7/dev/security/code-scanning/26)

To fix the problem, we need to avoid directly using the user-controlled input in the `run` command. Instead, we should set the untrusted input value to an intermediate environment variable and then use the environment variable using the native shell syntax. This approach mitigates the risk of code injection.

Specifically, we will:
1. Set the `github.event.head_commit.message` to an environment variable.
2. Use the environment variable in the `run` command with the native shell syntax.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
